### PR TITLE
Merge development to main 20240930_222500

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ create-release-tag: checkout-main bump
 
 create-gh-release: VERSION_BUMP:=$(shell python -m semver nextver $(VERSION) $(BUMP_LEVEL))
 create-gh-release: create-release-tag
-	gh release create -t v$(VERSION_BUMP) --generate-notes
+	gh release create -t v$(VERSION_BUMP) --generate-notes $(VERSION_BUMP)
 
 status:
 	git status

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ TIMESTAMP := $(shell /bin/date "+%Y%m%d_%H%M%S")
 VERSION := $(shell ./scripts/read-version.sh $(MAIN_EL))
 # BUMP_LEVEL: major|minor|patch|prerelease|build
 BUMP_LEVEL=patch
-VERSION_BUMP := $(shell python -m semver nextver $(VERSION) $(BUMP_LEVEL))
-VERSION_PRERELEASE := $(shell python -m semver nextver $(VERSION) prerelease)
+VERSION_BUMP := $(shell python -m semver bump $(BUMP_LEVEL) $(VERSION))
+VERSION_LAST_TAG := $(shell git tag --sort=-creatordate | head -n 1)
 
 .PHONY: tests					\
 create-pr					\
@@ -77,7 +77,7 @@ bump-casual:
 	sed -i 's/;; Version: $(VERSION)/;; Version: $(VERSION_BUMP)/' $(MAIN_EL)
 	sed -i 's/(defconst casual-symbol-overlay-version "$(VERSION)"/(defconst casual-symbol-overlay-version "$(VERSION_BUMP)"/' $(VERSION_EL)
 
-bump: checkout-development bump-casual
+bump: bump-casual
 	git commit -m 'Bump version to $(VERSION_BUMP)' $(MAIN_EL) $(VERSION_EL)
 	git push
 
@@ -96,16 +96,13 @@ checkout-main:
 sync-development-with-main: checkout-main checkout-development
 	git merge main
 
-new-sprint: sync-development-with-main
-	sed -i 's/;; Version: $(VERSION)/;; Version: $(VERSION_PRERELEASE)/' $(MAIN_EL)
-	sed -i 's/(defconst casual-symbol-overlay-version "$(VERSION)"/(defconst casual-symbol-overlay-version "$(VERSION_PRERELEASE)"/' $(MAIN_EL)
-	git commit -m 'Bump version to $(VERSION_PRERELEASE)' $(MAIN_EL)
-	git push
+
+new-sprint: VERSION_BUMP:=$(shell python -m semver nextver $(VERSION) prerelease)
+new-sprint: sync-development-with-main bump
 
 create-merge-development-branch: checkout-development
 	git checkout -b merge-development-to-main-$(TIMESTAMP)
 	git push --set-upstream origin merge-development-to-main-$(TIMESTAMP)
-
 
 ## Create GitHub pull request for development
 create-pr:
@@ -115,17 +112,18 @@ create-patch-pr:
 	gh pr create --base main --fill
 
 ## Create GitHub pull request for release
-create-release-pr: create-merge-development-branch bump
+create-release-pr: create-merge-development-branch
 	gh pr create --base main \
 --title "Merge development to main $(TIMESTAMP)" \
 --fill-verbose
 
-create-release-tag: checkout-main
-	git tag $(VERSION)
-	git push origin $(VERSION)
+create-release-tag: checkout-main bump
+	git tag $(VERSION_BUMP)
+	git push origin $(VERSION_BUMP)
 
+create-gh-release: VERSION_BUMP:=$(shell python -m semver nextver $(VERSION) $(BUMP_LEVEL))
 create-gh-release: create-release-tag
-	gh release create -t v$(VERSION) --notes-from-tag $(VERSION)
+	gh release create -t v$(VERSION_BUMP) --generate-notes
 
 status:
 	git status

--- a/README.org
+++ b/README.org
@@ -5,7 +5,7 @@ An opinionated [[https://github.com/magit/transient][Transient]]-based user inte
 
 * Motivation
 
-The *Symbol Overlay* (~symbol-overlay~) package has many useful functions and bindings that if not used frequently are easy to forget. Menus are a user interface (UI) affordance that offer users discoverability and recall that can lower its learning curve. While menus are commonly associated with mouse-driven UI, the inclusion of Transient in Emacs core allows for a menu UI that is keyboard-driven. Casual Symbol Overlay endeavors to offer this as many Emacs users prefer keyboard-driven workflows.
+The *Symbol Overlay* (~symbol-overlay~) package has many useful functions and bindings that if not used frequently are easy to forget. Menus are a user interface (UI) affordance that offer users discoverability and recognition that can lower its learning curve. While menus are commonly associated with mouse-driven UI, the inclusion of Transient in Emacs core allows for a menu UI that is keyboard-driven. Casual Symbol Overlay endeavors to offer this as many Emacs users prefer keyboard-driven workflows.
 
 ** Goals
 - To provide a keyboard-driven menu UI for editing symbol-overlay.

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -36,11 +36,11 @@ CASUAL_LIB_DIR=$(CASUAL_BASE_DIR)/casual-lib
 CASUAL_LIB_LISP_DIR=$(CASUAL_LIB_DIR)/lisp
 CASUAL_LIB_TEST_INCLUDES=$(CASUAL_LIB_DIR)/tests/casual-lib-test-utils.el
 EMACS_ELPA_DIR=$(HOME)/.config/emacs/elpa
-PACKAGE_PATHS=						\
--L $(EMACS_ELPA_DIR)/compat-30.0.0.0			\
--L $(EMACS_ELPA_DIR)/seq-2.24				\
--L $(EMACS_ELPA_DIR)/transient-current			\
--L $(EMACS_ELPA_DIR)/symbol-overlay-20240311.1207	\
+PACKAGE_PATHS=					\
+-L $(EMACS_ELPA_DIR)/compat-30.0.0.0		\
+-L $(EMACS_ELPA_DIR)/seq-2.24			\
+-L $(EMACS_ELPA_DIR)/transient-current		\
+-L $(EMACS_ELPA_DIR)/symbol-overlay-current	\
 -L $(CASUAL_LIB_LISP_DIR)
 
 .PHONY: tests compile regression

--- a/lisp/casual-symbol-overlay-version.el
+++ b/lisp/casual-symbol-overlay-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-symbol-overlay-version "1.0.1"
+(defconst casual-symbol-overlay-version "1.0.2-rc.1"
   "Casual Symbol Overlay Version.")
 
 (defun casual-symbol-overlay-version ()

--- a/lisp/casual-symbol-overlay.el
+++ b/lisp/casual-symbol-overlay.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-symbol-overlay
 ;; Keywords: tools
-;; Version: 1.0.1
+;; Version: 1.0.2-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0") (symbol-overlay "4.2"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Sync `Version:` commit with release tag for package build**
  This changes the build process to sync the package `Version:` field commit
  with the release tag. This is to support use-package :vc in the upcoming Emacs
  30 release.
  

- **Bump version to 1.0.2-rc.1**
  

- **Minor copy edit.**
  

- **Update package paths for regression tests.**
  