### PR TITLE
Offer symbol-overlay-mc-mark-all, if present

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,6 +22,9 @@ Casual Symbol Overlay requires usage of
 - Symbol Overlay ≥ 4.2
 - Casual ≥ 2.0.0
 
+If present, it will integrate with:
+- ~symbol-overlay-mc~ (for creating multiple cursors)
+
 Casual Symbol Overlay has been verified with the following configuration. 
 - Emacs 29.4 (macOS 14.5, Ubuntu Linux 22.04.4 LTS)
 

--- a/lisp/casual-symbol-overlay.el
+++ b/lisp/casual-symbol-overlay.el
@@ -110,6 +110,10 @@
                     (format "%s to last mark"
                             (casual-symbol-overlay-unicode-get :jump))))]]
 
+  ["Multiple cursors"
+   :if (lambda () (functionp #'symbol-overlay-mc-mark-all))
+   ("c" "Mark all" symbol-overlay-mc-mark-all)]
+
   [:class transient-row
    (casual-lib-quit-one)
    ("RET" "Done" transient-quit-all)


### PR DESCRIPTION
This function comes from package `symbol-overlay-mc`, which provides integration between the `symbol-overlay` and `multiple-cursors` packages.

https://github.com/xenodium/symbol-overlay-mc